### PR TITLE
Add parallax background system to NPC scene

### DIFF
--- a/Assets/Scenes/NPC.unity
+++ b/Assets/Scenes/NPC.unity
@@ -207,7 +207,7 @@ Transform:
   m_GameObject: {fileID: 38191358}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -4.5017076, y: -2.4058475, z: -10}
+  m_LocalPosition: {x: -4.5017076, y: -2.7558424, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -938,9 +938,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1101125058}
+  - component: {fileID: 1101125060}
   - component: {fileID: 1101125059}
   m_Layer: 4
-  m_Name: fondoo
+  m_Name: Layer-3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -956,7 +957,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -960, y: -540, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 1.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1814880594}
@@ -1007,7 +1008,7 @@ SpriteRenderer:
   m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 5
+  m_SortingOrder: 20
   m_Sprite: {fileID: 21300000, guid: 254a18b1d977bbe468e307e5c5decd8a, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -1019,6 +1020,19 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1101125060
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1101125057}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bde3e6fb5ed07e74997900ee48080ff7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ParallaxLayer
+  parallaxFactor: -0.1
 --- !u!1 &1160614002
 GameObject:
   m_ObjectHideFlags: 0
@@ -1283,10 +1297,11 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1242327904}
+  - component: {fileID: 1242327914}
   - component: {fileID: 1242327905}
   - component: {fileID: 1242327913}
   m_Layer: 4
-  m_Name: fondoo2
+  m_Name: Layer-2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1301,7 +1316,7 @@ Transform:
   m_GameObject: {fileID: 1242327903}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -960.1, y: -540.1, z: 0}
+  m_LocalPosition: {x: -960, y: -540, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1353,7 +1368,7 @@ SpriteRenderer:
   m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 2
+  m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: d0b16f52ab2938241af467ac3cf39ac2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -1427,6 +1442,19 @@ EdgeCollider2D:
   m_AdjacentEndPoint: {x: 0, y: 0}
   m_UseAdjacentStartPoint: 0
   m_UseAdjacentEndPoint: 0
+--- !u!114 &1242327914
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1242327903}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bde3e6fb5ed07e74997900ee48080ff7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ParallaxLayer
+  parallaxFactor: 0
 --- !u!1 &1338688909
 GameObject:
   m_ObjectHideFlags: 0
@@ -1444,7 +1472,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1338688910
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1461,11 +1489,11 @@ RectTransform:
   - {fileID: 686814626}
   m_Father: {fileID: 1038343826}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -20}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 20}
   m_SizeDelta: {x: 1700, y: 380}
-  m_Pivot: {x: 0.5, y: 1}
+  m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &1338688911
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1650,9 +1678,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1443626122}
+  - component: {fileID: 1443626124}
   - component: {fileID: 1443626123}
   m_Layer: 0
-  m_Name: fondoo4
+  m_Name: Layer-0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1731,6 +1760,19 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1443626124
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1443626121}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bde3e6fb5ed07e74997900ee48080ff7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ParallaxLayer
+  parallaxFactor: 0.2
 --- !u!1 &1482607315
 GameObject:
   m_ObjectHideFlags: 0
@@ -1740,9 +1782,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1482607316}
+  - component: {fileID: 1482607318}
   - component: {fileID: 1482607317}
   m_Layer: 0
-  m_Name: fondoo3
+  m_Name: Layer-1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1809,7 +1852,7 @@ SpriteRenderer:
   m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 1
+  m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: c62ca60c45159134ab71562618e0fdec, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -1821,6 +1864,19 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1482607318
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1482607315}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bde3e6fb5ed07e74997900ee48080ff7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ParallaxLayer
+  parallaxFactor: 0.1
 --- !u!1 &1498191421
 GameObject:
   m_ObjectHideFlags: 0
@@ -1912,6 +1968,7 @@ GameObject:
   - component: {fileID: 1558090085}
   - component: {fileID: 1558090084}
   - component: {fileID: 1558090087}
+  - component: {fileID: 1558090088}
   m_Layer: 0
   m_Name: CinemachineCamera
   m_TagString: Untagged
@@ -1937,7 +1994,7 @@ MonoBehaviour:
     AngularDampingMode: 0
     RotationDamping: {x: 1, y: 1, z: 1}
     QuaternionDamping: 1
-  FollowOffset: {x: 0, y: 1.5, z: -10}
+  FollowOffset: {x: 0, y: 0.8, z: -10}
 --- !u!114 &1558090085
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1990,7 +2047,7 @@ Transform:
   m_GameObject: {fileID: 1558090082}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -4.72934, y: -2.4058452, z: -10}
+  m_LocalPosition: {x: -4.72934, y: -2.755845, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2016,6 +2073,18 @@ MonoBehaviour:
     MaxWindowSize: 0
     Padding: 0
   m_LegacyMaxWindowSize: -2
+--- !u!114 &1558090088
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1558090082}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 210221ce64fdd8249be84c0643847621, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ParallaxCamera
 --- !u!1 &1689940322
 GameObject:
   m_ObjectHideFlags: 0
@@ -2061,6 +2130,7 @@ GameObject:
   - component: {fileID: 1814880594}
   - component: {fileID: 1814880593}
   - component: {fileID: 1814880592}
+  - component: {fileID: 1814880595}
   - component: {fileID: 1814880591}
   m_Layer: 5
   m_Name: Fondos
@@ -2098,10 +2168,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.CanvasScaler
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
+  m_ReferenceResolution: {x: 1920, y: 1080}
   m_ScreenMatchMode: 0
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3
@@ -2130,7 +2200,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 0
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 2
   m_TargetDisplay: 0
 --- !u!224 &1814880594
 RectTransform:
@@ -2144,10 +2214,10 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1101125058}
-  - {fileID: 1242327904}
-  - {fileID: 1482607316}
   - {fileID: 1443626122}
+  - {fileID: 1482607316}
+  - {fileID: 1242327904}
+  - {fileID: 1101125058}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -2155,6 +2225,19 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &1814880595
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1814880590}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d22e8d4bd9dfd784291feefdeb6e808c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ParallaxBackground
+  parallaxCamera: {fileID: 1558090088}
 --- !u!1 &1829791701
 GameObject:
   m_ObjectHideFlags: 0
@@ -2215,7 +2298,7 @@ MonoBehaviour:
   m_text: New Text
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 9127513212919007180, guid: 293644d84cbc65844a5cdf2486f42345, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/Assets/Scripts/Parallax.meta
+++ b/Assets/Scripts/Parallax.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 317d142ab7aeb864ea76c298593cb62f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Parallax/ParallaxBackground.cs.cs
+++ b/Assets/Scripts/Parallax/ParallaxBackground.cs.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[ExecuteInEditMode]
+public class ParallaxBackground : MonoBehaviour
+{
+    public ParallaxCamera parallaxCamera;
+    List<ParallaxLayer> parallaxLayers = new List<ParallaxLayer>();
+
+    void Start()
+    {
+        if (parallaxCamera == null)
+            parallaxCamera = Camera.main.GetComponent<ParallaxCamera>();
+
+        if (parallaxCamera != null)
+            parallaxCamera.onCameraTranslate += Move;
+
+        SetLayers();
+    }
+
+    void SetLayers()
+    {
+        parallaxLayers.Clear();
+
+        for (int i = 0; i < transform.childCount; i++)
+        {
+            ParallaxLayer layer = transform.GetChild(i).GetComponent<ParallaxLayer>();
+
+            if (layer != null)
+            {
+                layer.name = "Layer-" + i;
+                parallaxLayers.Add(layer);
+            }
+        }
+    }
+
+    void Move(float delta)
+    {
+        foreach (ParallaxLayer layer in parallaxLayers)
+        {
+            layer.Move(delta);
+        }
+    }
+}

--- a/Assets/Scripts/Parallax/ParallaxBackground.cs.cs.meta
+++ b/Assets/Scripts/Parallax/ParallaxBackground.cs.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d22e8d4bd9dfd784291feefdeb6e808c

--- a/Assets/Scripts/Parallax/ParallaxCamera.cs.cs
+++ b/Assets/Scripts/Parallax/ParallaxCamera.cs.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+[ExecuteInEditMode]
+public class ParallaxCamera : MonoBehaviour
+{
+    public delegate void ParallaxCameraDelegate(float deltaMovement);
+    public ParallaxCameraDelegate onCameraTranslate;
+
+    private float oldPosition;
+
+    void Start()
+    {
+        oldPosition = transform.position.x;
+    }
+
+    void Update()
+    {
+        if (transform.position.x != oldPosition)
+        {
+            if (onCameraTranslate != null)
+            {
+                float delta = oldPosition - transform.position.x;
+                onCameraTranslate(delta);
+            }
+
+            oldPosition = transform.position.x;
+        }
+    }
+}

--- a/Assets/Scripts/Parallax/ParallaxCamera.cs.cs.meta
+++ b/Assets/Scripts/Parallax/ParallaxCamera.cs.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 210221ce64fdd8249be84c0643847621

--- a/Assets/Scripts/Parallax/ParallaxLayer.cs.cs
+++ b/Assets/Scripts/Parallax/ParallaxLayer.cs.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+[ExecuteInEditMode]
+public class ParallaxLayer : MonoBehaviour
+{
+    public float parallaxFactor;
+
+    public void Move(float delta)
+    {
+        Vector3 newPos = transform.localPosition;
+        newPos.x -= delta * parallaxFactor;
+
+        transform.localPosition = newPos;
+    }
+
+}

--- a/Assets/Scripts/Parallax/ParallaxLayer.cs.cs.meta
+++ b/Assets/Scripts/Parallax/ParallaxLayer.cs.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bde3e6fb5ed07e74997900ee48080ff7

--- a/Assets/babel/Dafne/fondoo.png.meta
+++ b/Assets/babel/Dafne/fondoo.png.meta
@@ -52,7 +52,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -90,7 +90,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/Assets/babel/Dafne/fondoo2.png.meta
+++ b/Assets/babel/Dafne/fondoo2.png.meta
@@ -49,7 +49,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -87,7 +87,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/Assets/babel/Dafne/fondoo3.png.meta
+++ b/Assets/babel/Dafne/fondoo3.png.meta
@@ -43,7 +43,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -81,7 +81,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/Assets/babel/Dafne/fondoo4.png.meta
+++ b/Assets/babel/Dafne/fondoo4.png.meta
@@ -37,7 +37,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -75,7 +75,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0


### PR DESCRIPTION
Introduced ParallaxBackground, ParallaxCamera, and ParallaxLayer scripts to enable parallax scrolling in the NPC scene. Updated the scene to use new parallax layers, adjusted GameObject names and hierarchy, and configured sorting orders and parallax factors. Also updated texture import settings for background images to use point filtering and no compression.